### PR TITLE
feat(calendar/reports): reconcile session & report interfaces

### DIFF
--- a/models/session.py
+++ b/models/session.py
@@ -18,6 +18,8 @@ class Session(db.Model):
     status = db.Column(db.String(50), default='Scheduled')
     location = db.Column(db.String(100))
     notes = db.Column(db.Text)
+    event_type = db.Column(db.String(50), default='Session')
+    plan_notes = db.Column(db.Text)
     
     # Billing information
     billing_code = db.Column(db.String(20))
@@ -52,9 +54,34 @@ class Session(db.Model):
             'status': self.status,
             'location': self.location,
             'notes': self.notes,
+            'event_type': self.event_type,
+            'plan_notes': self.plan_notes,
             'duration_minutes': self.duration_minutes,
             'billing_code': self.billing_code,
             'units': self.units
+        }
+
+    def to_calendar_event(self):
+        """Convert session to calendar event representation."""
+        start_dt = None
+        end_dt = None
+        if self.session_date and self.start_time:
+            start_dt = datetime.combine(self.session_date, self.start_time)
+        if self.session_date and self.end_time:
+            end_dt = datetime.combine(self.session_date, self.end_time)
+
+        return {
+            'id': self.id,
+            'student_id': self.student_id,
+            'title': self.student.display_name if self.student else f'Session {self.id}',
+            'start': start_dt.isoformat() if start_dt else None,
+            'end': end_dt.isoformat() if end_dt else None,
+            'event_type': self.event_type,
+            'session_type': self.session_type,
+            'status': self.status,
+            'location': self.location,
+            'notes': self.notes,
+            'plan_notes': self.plan_notes,
         }
 
 class TrialLog(db.Model):

--- a/routes/reports.py
+++ b/routes/reports.py
@@ -87,7 +87,7 @@ def get_student_progress_report(student_id):
                         progress_points.append({
                             'date': log.session_date.isoformat(),
                             'independence_rate': independence_rate,
-                            'total_trials': log.total_trials_new()
+                            'total_trials': log.total_trials
                         })
                     
                     # Calculate trend

--- a/utils/quarterly_reports.py
+++ b/utils/quarterly_reports.py
@@ -256,7 +256,7 @@ Monthly Breakdown:"""
                 sessions_data[date_key] = []
             sessions_data[date_key].append(log)
         
-        total_trials = sum(log.total_trials_new() for log in trial_logs)
+        total_trials = sum(log.total_trials for log in trial_logs)
         independent_trials = sum(log.independent for log in trial_logs)
         correct_trials = sum(
             log.independent + log.minimal_support + 
@@ -293,7 +293,7 @@ Monthly Breakdown:"""
                 daily_rates[date_key] = {'independent': 0, 'total': 0}
             
             daily_rates[date_key]['independent'] += log.independent
-            daily_rates[date_key]['total'] += log.total_trials_new()
+            daily_rates[date_key]['total'] += log.total_trials
         
         # Calculate independence percentage for each day
         dates = sorted(daily_rates.keys())
@@ -383,7 +383,7 @@ Monthly Breakdown:"""
             return "\nOVERALL SUMMARY\n\nNo trial data available for this reporting period."
         
         # Calculate overall metrics
-        total_trials = sum(log.total_trials_new() for log in trial_logs)
+        total_trials = sum(log.total_trials for log in trial_logs)
         independent_trials = sum(log.independent for log in trial_logs)
         overall_independence = (independent_trials / total_trials * 100) if total_trials > 0 else 0
         
@@ -420,7 +420,7 @@ Key Highlights:
             return recommendations
         
         # Calculate overall progress
-        total_trials = sum(log.total_trials_new() for log in trial_logs)
+        total_trials = sum(log.total_trials for log in trial_logs)
         independent_trials = sum(log.independent for log in trial_logs)
         overall_independence = (independent_trials / total_trials * 100) if total_trials > 0 else 0
         

--- a/utils/reports.py
+++ b/utils/reports.py
@@ -64,7 +64,7 @@ def calculate_progress_metrics(trial_logs: List[TrialLog], goals: List[Goal]) ->
         }
     
     # Overall metrics
-    total_trials = sum(log.total_trials_new() for log in trial_logs)
+    total_trials = sum(log.total_trials for log in trial_logs)
     total_independent = sum(log.independent for log in trial_logs)
     average_independence = round((total_independent / total_trials) * 100, 1) if total_trials > 0 else 0
     
@@ -94,7 +94,7 @@ def calculate_progress_metrics(trial_logs: List[TrialLog], goals: List[Goal]) ->
         
         if goal_logs:
             goal_independence = calculate_independence_rate(goal_logs)
-            goal_trials = sum(log.total_trials_new() for log in goal_logs)
+            goal_trials = sum(log.total_trials for log in goal_logs)
             
             goal_progress.append({
                 'goal_id': goal.id,
@@ -117,7 +117,7 @@ def calculate_independence_rate(trial_logs: List[TrialLog]) -> float:
     if not trial_logs:
         return 0.0
     
-    total_trials = sum(log.total_trials_new() for log in trial_logs)
+    total_trials = sum(log.total_trials for log in trial_logs)
     total_independent = sum(log.independent for log in trial_logs)
     
     return round((total_independent / total_trials) * 100, 1) if total_trials > 0 else 0.0
@@ -218,7 +218,7 @@ def generate_analytics_data(date_range: Tuple[date, date]) -> Dict:
     ).all()
     
     if trial_logs:
-        total_trials = sum(log.total_trials_new() for log in trial_logs)
+        total_trials = sum(log.total_trials for log in trial_logs)
         average_independence = calculate_independence_rate(trial_logs)
     else:
         total_trials = 0

--- a/utils/soap_generator.py
+++ b/utils/soap_generator.py
@@ -190,7 +190,7 @@ class SOAPGenerator:
                              area_data.get('objective_id') == log.objective_id]
                 
                 accuracy = self._calculate_accuracy(area_trials)
-                total_trials = sum(log.total_trials_new() for log in area_trials)
+                total_trials = sum(log.total_trials for log in area_trials)
                 support_level = self._determine_support_level(area_trials)
                 
                 objective_text = template.format(
@@ -308,7 +308,7 @@ class SOAPGenerator:
         if not trial_logs:
             return 0
             
-        total_trials = sum(log.total_trials_new() for log in trial_logs)
+        total_trials = sum(log.total_trials for log in trial_logs)
         correct_trials = sum(
             log.independent + log.minimal_support + 
             log.moderate_support + log.maximal_support 
@@ -322,7 +322,7 @@ class SOAPGenerator:
         if not trial_logs:
             return 0
             
-        total_trials = sum(log.total_trials_new() for log in trial_logs)
+        total_trials = sum(log.total_trials for log in trial_logs)
         independent_trials = sum(log.independent for log in trial_logs)
         
         return round((independent_trials / total_trials * 100)) if total_trials > 0 else 0


### PR DESCRIPTION
## Summary
- add `event_type` and `plan_notes` columns and a `to_calendar_event` helper on `Session`
- update reporting helpers and routes to use `TrialLog.total_trials`
- clean up reporting utilities referencing non-existent `total_trials_new`

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`
- `python3 -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a3735da25c8320bc4773c24e505ea6